### PR TITLE
Add Django 4.0 support, drop Django < 2

### DIFF
--- a/mezzanine_pagedown/urls.py
+++ b/mezzanine_pagedown/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .views import MarkupPreview
 
-urlpatterns = [url(r'^preview/$', MarkupPreview.as_view(), name='preview'), ]
+urlpatterns = [path('preview/', MarkupPreview.as_view(), name='preview'), ]

--- a/mezzanine_pagedown/widgets.py
+++ b/mezzanine_pagedown/widgets.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django import VERSION as DJANGO_VERSION
 if DJANGO_VERSION < (1, 8):
     from django.forms.util import flatatt
@@ -45,7 +45,7 @@ class PageDownWidget(forms.Textarea):
             del final_attrs['id']
         return mark_safe(render_to_string(self.template, {
             'final_attrs': flatatt(final_attrs),
-            'value': conditional_escape(force_text(value)),
+            'value': conditional_escape(force_str(value)),
             'id': final_id,
             'server_side_preview': settings.PAGEDOWN_SERVER_SIDE_PREVIEW,
         }))


### PR DESCRIPTION
django.urls.path is available since Django 2.0, so drop support
for older Django versions which should not be used nowadays anyway.