### PR TITLE
Add support for Bleach 5

### DIFF
--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -2,14 +2,24 @@ from mezzanine.conf import settings
 
 from markdown import markdown
 from bleach import clean
+try:
+    from bleach.css_sanitizer import CSSSanitizer
+except ImportError:
+    CSSSanitizer = None
 
 
 def _clean(html):
     tags = settings.RICHTEXT_ALLOWED_TAGS
     attrs = list(settings.RICHTEXT_ALLOWED_ATTRIBUTES)
-    styles = settings.RICHTEXT_ALLOWED_STYLES
+    if CSSSanitizer is not None:
+        # Bleach 5
+        styles_options = {'css_sanitizer': CSSSanitizer(
+            allowed_css_properties=settings.RICHTEXT_ALLOWED_STYLES
+        )}
+    else:
+        styles_options = {'styles': settings.RICHTEXT_ALLOWED_STYLES}
     return clean(html, tags=tags, attributes=attrs, strip=True,
-                 strip_comments=False, styles=styles)
+                 strip_comments=False, **styles_options)
 
 
 def codehilite(content):


### PR DESCRIPTION
Bleach 5 (which is required since Mezzanine 6.0) has a backwards incompatible change in the "clean" method and needs a CSSSanitizer instance instead of a plain list of CSS styles.

For details see https://github.com/mozilla/bleach/blob/main/CHANGES.

@akhayyat a new release afterwards would be fine.